### PR TITLE
reworked test case register api

### DIFF
--- a/interface_tester/__init__.py
+++ b/interface_tester/__init__.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 import pytest
 
-from .interface_test import interface_test_case  # noqa: F401
+from .interface_test import register_test_case  # noqa: F401
 from .plugin import InterfaceTester
 from .schema_base import DataBagSchema  # noqa: F401
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "0.1.1"
+version = "0.2"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]


### PR DESCRIPTION
Moved from decorator approach to an explicit `register_test_case` function call. 
before
```
from interface_tester import interface_test_case
@interface_test_case
def foo(state_out):
    return None
```

this proposal:
```
from interface_tester import register_interface_test
register_interface_test(..., validator=lambda state_out: None) # optional; defaults to None)
```

Reason: in most cases, an explicit output state validator (what the decorated function represents) is not necessary.
Downsides: the decorator approach nudged you into giving each test a unique name. Right now you'd need to pass a name yourself and we don't guarantee uniqueness. It's more of a nice-to-have (a human reader will have an easier time debugging if each test has a unique, human-readable name) though.

Thoughts:
- make `name` a mandatory arg? @simskij @gruyaume?