### PR TITLE
Unpin pydantic version

### DIFF
--- a/interface_tester/__init__.py
+++ b/interface_tester/__init__.py
@@ -2,9 +2,11 @@
 # See LICENSE file for licensing details.
 import pytest
 
-from interface_tester.interface_test import Tester  # noqa F401
+from interface_tester.interface_test import Tester
 from interface_tester.plugin import InterfaceTester
-from interface_tester.schema_base import DataBagSchema  # noqa: F401
+from interface_tester.schema_base import DataBagSchema
+
+__all__ = ["Tester", "InterfaceTester", "DataBagSchema"]
 
 
 @pytest.fixture(scope="function")

--- a/interface_tester/__init__.py
+++ b/interface_tester/__init__.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 import pytest
 
-from interface_tester.interface_test import Tester
+from interface_tester.interface_test import Tester  # noqa F401
 from interface_tester.plugin import InterfaceTester
 from interface_tester.schema_base import DataBagSchema  # noqa: F401
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "relation interfaces"]
 
 dependencies = [
-    "pydantic==1.10.7",
+    "pydantic>= 1.10.7, <2",
     "typer==0.7.0",
     "ops-scenario>=5.2",
     "pytest"


### PR DESCRIPTION
Unpin pydantic version, allowing more recent compatible versions to be required by the charms using the interface tester