### PR TITLE
strip .git extension if provided in repo

### DIFF
--- a/interface_tester/plugin.py
+++ b/interface_tester/plugin.py
@@ -188,6 +188,9 @@ class InterfaceTester:
                 )
 
             repo_name = self._repo.split("/")[-1]
+            if repo_name.endswith(".git"):
+                repo_name = repo_name.rsplit(".", maxsplit=1)[0]
+
             intf_spec_path = (
                 Path(tempdir)
                 / repo_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "1.0.4"
+version = "1.0.5"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]


### PR DESCRIPTION
if the user passes a custom `repo` to the interface_tester, accept it if it ends with the `.git` extension instead of raising obscure errors