### PR TITLE
Juju version support

### DIFF
--- a/interface_tester/interface_test.py
+++ b/interface_tester/interface_test.py
@@ -376,14 +376,14 @@ class Tester:
 
         kwargs = {}
         if self.ctx.juju_version:
-            kwargs['juju_version'] = self.ctx.juju_version
+            kwargs["juju_version"] = self.ctx.juju_version
 
         ctx = Context(
             self.ctx.charm_type,
             meta=self.ctx.meta,
             actions=self.ctx.actions,
             config=self.ctx.config,
-            **kwargs
+            **kwargs,
         )
         return ctx.run(event, state)
 

--- a/interface_tester/interface_test.py
+++ b/interface_tester/interface_test.py
@@ -69,6 +69,9 @@ class _InterfaceTestContext:
     input_state: Optional[State] = None
     """Initial state that this test should be run with, according to the test."""
 
+    juju_version: Optional[str] = None
+    """The juju version Scenario will simulate. Defaults to whatever Scenario's default is."""
+
 
 def check_test_case_validator_signature(fn: Callable):
     """Verify the signature of a test case validator function.
@@ -371,11 +374,16 @@ class Tester:
     def _run_scenario(self, event: Event, state: State):
         logger.debug("running scenario with state=%s, event=%s" % (state, event))
 
+        kwargs = {}
+        if self.ctx.juju_version:
+            kwargs['juju_version'] = self.ctx.juju_version
+
         ctx = Context(
             self.ctx.charm_type,
             meta=self.ctx.meta,
             actions=self.ctx.actions,
             config=self.ctx.config,
+            **kwargs
         )
         return ctx.run(event, state)
 

--- a/interface_tester/plugin.py
+++ b/interface_tester/plugin.py
@@ -48,6 +48,7 @@ class InterfaceTester:
         self._config = None
         self._interface_name = None
         self._interface_version = 0
+        self._juju_version = None
         self._state_template = None
 
         self._charm_spec_cache = None
@@ -62,6 +63,7 @@ class InterfaceTester:
         interface_name: Optional[str] = None,
         interface_version: Optional[int] = None,
         state_template: Optional[State] = None,
+        juju_version: Optional[str] = None,
         meta: Optional[Dict[str, Any]] = None,
         actions: Optional[Dict[str, Any]] = None,
         config: Optional[Dict[str, Any]] = None,
@@ -79,6 +81,8 @@ class InterfaceTester:
         :param meta: charm metadata.yaml contents.
         :param actions: charm actions.yaml contents.
         :param config: charm config.yaml contents.
+        :param juju_version: juju version that Scenario will simulate (also sets JUJU_VERSION
+            envvar at charm runtime.)
         """
         if charm_type:
             self._charm_type = charm_type
@@ -100,6 +104,8 @@ class InterfaceTester:
             self._branch = branch
         if base_path:
             self._base_path = base_path
+        if juju_version:
+            self._juju_version = juju_version
 
     def _validate_config(self):
         """Validate the configuration of the tester.
@@ -290,6 +296,7 @@ class InterfaceTester:
         \tconfig={self._config}
         \tinterface_name={self._interface_name}
         \tinterface_version={self._interface_version}
+        \tjuju_version={self._juju_version}
         \tstate_template={self._state_template}>"""
 
     def run(self) -> bool:
@@ -315,6 +322,7 @@ class InterfaceTester:
                 actions=self.actions,
                 supported_endpoints=self._gather_supported_endpoints(),
                 test_fn=test_fn,
+                juju_version=self._juju_version,
             )
             try:
                 with tester_context(ctx):


### PR DESCRIPTION
allows passing `juju-version` to interface tester configuration
 `interface_tester.configure(juju_version="3.4")`
 
 this will set JUJU_VERSION in the charm runtime env, and it will ask scenario to simulate that juju version's functionality.