### PR TITLE
fixed endpoint determination from input_state

### DIFF
--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -107,8 +107,8 @@ def load_schema_module(schema_path: Path) -> types.ModuleType:
 
     # Otherwise we'll get an error when we re-run @validator
     # fixme: is there a better way to do this?
-    logger.debug("Clearing pydantic.class_validators._FUNCS")
-    pydantic.class_validators._FUNCS.clear()  # noqa
+    # logger.debug("Clearing pydantic.class_validators._FUNCS")
+    # pydantic.class_validators._FUNCS.clear()  # noqa
 
     try:
         module = importlib.import_module(module_name)

--- a/interface_tester/interface_test.py
+++ b/interface_tester/interface_test.py
@@ -480,7 +480,9 @@ class Tester:
 
             # relations that come from the state_template presumably have the right endpoint,
             # but those that we get from interface tests cannot.
-            relations_with_endpoint = [r.replace(endpoint=endpoint) for r in relations_from_input_state]
+            relations_with_endpoint = [
+                r.replace(endpoint=endpoint) for r in relations_from_input_state
+            ]
 
             relations.extend(relations_with_endpoint)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "relation interfaces"]
 
 dependencies = [
-    "pydantic>= 1.10.7, <2",
+    "pydantic>2",
     "typer==0.7.0",
     "ops-scenario>=5.2",
     "pytest"

--- a/tests/unit/test_collect_schemas.py
+++ b/tests/unit/test_collect_schemas.py
@@ -35,7 +35,7 @@ def test_collect_schemas(tmp_path):
             """from interface_tester.schema_base import DataBagSchema
                 
 class RequirerSchema(DataBagSchema):
-    foo = 1"""
+    foo: int = 1"""
         )
     )
 
@@ -54,7 +54,7 @@ def test_collect_schemas_multiple(tmp_path):
             """from interface_tester.schema_base import DataBagSchema
 
 class RequirerSchema(DataBagSchema):
-    foo = 1"""
+    foo:int = 1"""
         )
     )
 
@@ -65,7 +65,7 @@ class RequirerSchema(DataBagSchema):
             """from interface_tester.schema_base import DataBagSchema
 
 class RequirerSchema(DataBagSchema):
-    foo = 2"""
+    foo:int = 2"""
         )
     )
 
@@ -84,7 +84,7 @@ def test_collect_invalid_schemas(tmp_path):
         dedent(
             """from interface_tester.schema_base import DataBagSchema
 class ProviderSchema(DataBagSchema):
-    foo = 2"""
+    foo:int = 2"""
         )
     )
 

--- a/tests/unit/test_e2e.py
+++ b/tests/unit/test_e2e.py
@@ -107,7 +107,7 @@ from interface_tester.interface_test import Tester
 def test_data_on_changed():
     t = Tester(State(
         relations=[Relation(
-            endpoint='tracing',
+            endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
             interface='tracing',
             remote_app_name='remote',
             local_app_data={}
@@ -133,7 +133,7 @@ from interface_tester.interface_test import Tester
 def test_data_on_changed():
     t = Tester(State(
         relations=[Relation(
-            endpoint='tracing',
+            endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
             interface='tracing',
             remote_app_name='remote',
             local_app_data={}
@@ -160,7 +160,7 @@ from interface_tester.interface_test import Tester
 def test_data_on_changed():
     t = Tester(State(
         relations=[Relation(
-            endpoint='tracing',
+            endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
             interface='tracing',
             remote_app_name='remote',
             local_app_data={}
@@ -186,7 +186,7 @@ from interface_tester.interface_test import Tester
 def test_data_on_changed():
     t = Tester(State(
         relations=[Relation(
-            endpoint='tracing',
+            endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
             interface='tracing',
             remote_app_name='remote',
             local_app_data={}
@@ -213,7 +213,7 @@ from interface_tester.interface_test import Tester
 def test_data_on_changed():
     t = Tester(State(
         relations=[Relation(
-            endpoint='tracing',
+            endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
             interface='tracing',
             remote_app_name='remote',
             local_app_data={}
@@ -239,7 +239,7 @@ from interface_tester.interface_test import Tester
 def test_data_on_changed():
     t = Tester(State(
         relations=[Relation(
-            endpoint='tracing',
+            endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
             interface='tracing',
             remote_app_name='remote',
             local_app_data={}
@@ -285,7 +285,7 @@ def test_valid_run():
  def test_data_on_changed():
      t = Tester(State(
          relations=[Relation(
-             endpoint='tracing',
+             endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
              interface='tracing',
              remote_app_name='remote',
              local_app_data={}
@@ -312,7 +312,7 @@ def test_valid_run_default_schema():
  def test_data_on_changed():
      t = Tester(State(
          relations=[Relation(
-             endpoint='tracing',
+             endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
              interface='tracing',
              remote_app_name='remote',
              local_app_data={"foo":"1"},
@@ -355,7 +355,7 @@ def test_default_schema_validation_failure():
  def test_data_on_changed():
      t = Tester(State(
          relations=[Relation(
-             endpoint='tracing',
+             endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
              interface='tracing',
              remote_app_name='remote',
              local_app_data={"foo":"abc"},
@@ -408,7 +408,7 @@ def test_valid_run_custom_schema():
  def test_data_on_changed():
      t = Tester(State(
          relations=[Relation(
-             endpoint='tracing',
+             endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
              interface='tracing',
              remote_app_name='remote',
              local_app_data={"foo":"1"},
@@ -445,7 +445,7 @@ def test_invalid_custom_schema():
  def test_data_on_changed():
      t = Tester(State(
          relations=[Relation(
-             endpoint='tracing',
+             endpoint='foobadooble',  # should not matter: the charm says on what endpoint it uses 'tracing'
              interface='tracing',
              remote_app_name='remote',
              local_app_data={"foo":"abc"},


### PR DESCRIPTION
the endpoint defined by interface tests should not matter, as the charm-defined endpoint name should be used.

Fixes #14 