### PR TITLE
Add `owners` in `interface.yaml`

### DIFF
--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -175,7 +175,7 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
 
     providers = charms.get("providers", [])
     requirers = charms.get("requirers", [])
-    owners = charms.get("owners", "")
+    owners = charms.get("owners") or []
 
     if not isinstance(providers, list) or not isinstance(requirers, list):
         raise TypeError(
@@ -277,7 +277,7 @@ def gather_test_spec_for_version(
             "schema": schemas.get("requirer"),
             "charms": charms.get("requirers", []) if charms else [],
         },
-        "owners": charms.get("owners", "") if charms else "",
+        "owners": charms.get("owners") or [] if charms else [],
     }
 
 

--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -82,6 +82,7 @@ class InterfaceTestSpec(TypedDict):
 
     provider: _RoleTestSpec
     requirer: _RoleTestSpec
+    owner: str
 
 
 def get_schema_from_module(module: object, name: str) -> Type[pydantic.BaseModel]:

--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -66,6 +66,7 @@ class _InterfacesDotYamlSpec(TypedDict):
 
     providers: List[_CharmTestConfig]
     requirers: List[_CharmTestConfig]
+    owner: str
 
 
 class _RoleTestSpec(TypedDict):
@@ -173,6 +174,7 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
 
     providers = charms.get("providers", [])
     requirers = charms.get("requirers", [])
+    owner = charms.get("owner", "")
 
     if not isinstance(providers, list) or not isinstance(requirers, list):
         raise TypeError(
@@ -196,7 +198,11 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
                 continue
             destination.append(cfg)
 
-    spec: _InterfacesDotYamlSpec = {"providers": provider_configs, "requirers": requirer_configs}
+    spec: _InterfacesDotYamlSpec = {
+        "providers": provider_configs,
+        "requirers": requirer_configs,
+        "owner": owner,
+    }
     return spec
 
 
@@ -270,6 +276,7 @@ def gather_test_spec_for_version(
             "schema": schemas.get("requirer"),
             "charms": charms.get("requirers", []) if charms else [],
         },
+        "owner": charms.get("owner", "") if charms else "",
     }
 
 

--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -173,8 +173,8 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
     if not charms:
         return None
 
-    providers = charms.get("providers", [])
-    requirers = charms.get("requirers", [])
+    providers = charms.get("providers") or []
+    requirers = charms.get("requirers") or []
     owners = charms.get("owners") or []
 
     if not isinstance(providers, list) or not isinstance(requirers, list):

--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -66,7 +66,7 @@ class _InterfacesDotYamlSpec(TypedDict):
 
     providers: List[_CharmTestConfig]
     requirers: List[_CharmTestConfig]
-    owner: str
+    owners: List[str]
 
 
 class _RoleTestSpec(TypedDict):
@@ -82,7 +82,7 @@ class InterfaceTestSpec(TypedDict):
 
     provider: _RoleTestSpec
     requirer: _RoleTestSpec
-    owner: str
+    owners: List[str]
 
 
 def get_schema_from_module(module: object, name: str) -> Type[pydantic.BaseModel]:
@@ -175,7 +175,7 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
 
     providers = charms.get("providers", [])
     requirers = charms.get("requirers", [])
-    owner = charms.get("owner", "")
+    owners = charms.get("owners", "")
 
     if not isinstance(providers, list) or not isinstance(requirers, list):
         raise TypeError(
@@ -202,7 +202,7 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
     spec: _InterfacesDotYamlSpec = {
         "providers": provider_configs,
         "requirers": requirer_configs,
-        "owner": owner,
+        "owners": owners,
     }
     return spec
 
@@ -277,7 +277,7 @@ def gather_test_spec_for_version(
             "schema": schemas.get("requirer"),
             "charms": charms.get("requirers", []) if charms else [],
         },
-        "owner": charms.get("owner", "") if charms else "",
+        "owners": charms.get("owners", "") if charms else "",
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "3.0.0"
+version = "3.1.0"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]


### PR DESCRIPTION
Background:

We would like to run the [charm-relation-interfaces](https://github.com/canonical/charm-relation-interfaces) tests on a schedule using a GitHub Actions cron job, and if a certain interface test failed, we'd like to automatically create an issue and assign it to the owner (if specified).

This PR adds support to define the `owners` field (a list of GitHub user IDs) in `interface.yaml`. Example:

```yaml
name: prometheus_scrape

version: 0
status: published

providers:
  - name: prometheus-k8s
    url: https://www.github.com/canonical/prometheus-k8s-operator

requirers:
  - name: prometheus-k8s
    url: https://www.github.com/canonical/prometheus-k8s-operator

owners:
  - ironcore864
  - foo
  - bar
```
