### PR TITLE
feat: change owners to maintainers

### DIFF
--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -175,7 +175,7 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
 
     providers = charms.get("providers") or []
     requirers = charms.get("requirers") or []
-    maintainers = charms.get("maintainers", "")
+    maintainers = charms.get("maintainers") or ""
 
     if not isinstance(providers, list) or not isinstance(requirers, list):
         raise TypeError(

--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -277,7 +277,7 @@ def gather_test_spec_for_version(
             "schema": schemas.get("requirer"),
             "charms": charms.get("requirers", []) if charms else [],
         },
-        "maintainers": charms.get("maintainers", "") if charms else "",
+        "maintainers": charms.get("maintainers") or "" if charms else "",
     }
 
 

--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -66,7 +66,7 @@ class _InterfacesDotYamlSpec(TypedDict):
 
     providers: List[_CharmTestConfig]
     requirers: List[_CharmTestConfig]
-    maintainers: str
+    maintainer: str
 
 
 class _RoleTestSpec(TypedDict):
@@ -82,7 +82,7 @@ class InterfaceTestSpec(TypedDict):
 
     provider: _RoleTestSpec
     requirer: _RoleTestSpec
-    maintainers: str
+    maintainer: str
 
 
 def get_schema_from_module(module: object, name: str) -> Type[pydantic.BaseModel]:
@@ -175,7 +175,7 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
 
     providers = charms.get("providers") or []
     requirers = charms.get("requirers") or []
-    maintainers = charms.get("maintainers") or ""
+    maintainer = charms.get("maintainer") or ""
 
     if not isinstance(providers, list) or not isinstance(requirers, list):
         raise TypeError(
@@ -202,7 +202,7 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
     spec: _InterfacesDotYamlSpec = {
         "providers": provider_configs,
         "requirers": requirer_configs,
-        "maintainers": maintainers,
+        "maintainer": maintainer,
     }
     return spec
 
@@ -277,7 +277,7 @@ def gather_test_spec_for_version(
             "schema": schemas.get("requirer"),
             "charms": charms.get("requirers", []) if charms else [],
         },
-        "maintainers": charms.get("maintainers") or "" if charms else "",
+        "maintainer": charms.get("maintainer") or "" if charms else "",
     }
 
 

--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -66,7 +66,7 @@ class _InterfacesDotYamlSpec(TypedDict):
 
     providers: List[_CharmTestConfig]
     requirers: List[_CharmTestConfig]
-    owners: List[str]
+    maintainers: str
 
 
 class _RoleTestSpec(TypedDict):
@@ -82,7 +82,7 @@ class InterfaceTestSpec(TypedDict):
 
     provider: _RoleTestSpec
     requirer: _RoleTestSpec
-    owners: List[str]
+    maintainers: str
 
 
 def get_schema_from_module(module: object, name: str) -> Type[pydantic.BaseModel]:
@@ -175,7 +175,7 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
 
     providers = charms.get("providers") or []
     requirers = charms.get("requirers") or []
-    owners = charms.get("owners") or []
+    maintainers = charms.get("maintainers", "")
 
     if not isinstance(providers, list) or not isinstance(requirers, list):
         raise TypeError(
@@ -202,7 +202,7 @@ def _gather_charms_for_version(version_dir: Path) -> Optional[_InterfacesDotYaml
     spec: _InterfacesDotYamlSpec = {
         "providers": provider_configs,
         "requirers": requirer_configs,
-        "owners": owners,
+        "maintainers": maintainers,
     }
     return spec
 
@@ -277,7 +277,7 @@ def gather_test_spec_for_version(
             "schema": schemas.get("requirer"),
             "charms": charms.get("requirers", []) if charms else [],
         },
-        "owners": charms.get("owners") or [] if charms else [],
+        "maintainers": charms.get("maintainers", "") if charms else "",
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "3.1.0"
+version = "3.1.1"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]


### PR DESCRIPTION
Per discussions in [this issue](https://github.com/canonical/charm-relation-interfaces/pull/168) (see comment [here](https://github.com/canonical/charm-relation-interfaces/pull/168#issuecomment-2314981570) and [here](https://github.com/canonical/charm-relation-interfaces/pull/168#issuecomment-2316508980)) and an email thread, we have agreed to the followings:

- Use "maintainers" instead of "owners", because "owners" indicates ownership while the interface is meant to be "owned" by a group around it.
- Put a GitHub team ID as "maintainers", instead of a list of users. This eliminates the overhead of maintaining the list of user IDs. The purpose of this field is to assign issues to users when a certain interface test fails; although it's not supported to assign an issue to a team, this can be worked out in the [`charm-relation-interfaces`](https://github.com/canonical/charm-relation-interfaces) repo's [`run_matrix.py`](https://github.com/canonical/charm-relation-interfaces/blob/main/run_matrix.py) script.

This PR to `pytest-interface-tester` reflects the above changes.

See the other part of the change in the [`charm-relation-interfaces`](https://github.com/canonical/charm-relation-interfaces) repo.

An extra note on the version: It has not been used since the last release, 3.1.0. So, although this PR technically is a breaking change, it doesn’t break anything. That’s why I only slightly bumped the version to 3.1.1, not strictly following the SEMVER rules.