### PR TITLE
chore: 3.2 release for the maintainer feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "3.2"
+version = "3.2.0"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "3.1.1"
+version = "3.2"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]


### PR DESCRIPTION
Bump version to 3.2 to include the maintainer feature (already merged into main without a new version).