### PR TITLE
fix: ensure that `event` is set when using an `_Event` object

### DIFF
--- a/interface_tester/interface_test.py
+++ b/interface_tester/interface_test.py
@@ -435,6 +435,8 @@ class Tester:
                 raise InvalidTestCaseError(
                     f"Bad interface test specification: event {raw_event} is not a relation event."
                 )
+        else:
+            event = raw_event
 
         # todo: if the user passes a relation event that is NOT about the relation
         #  interface that this test is about, at this point we are injecting the wrong

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "3.1.1"
+version = "3.1.2"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]

--- a/tests/unit/test_e2e.py
+++ b/tests/unit/test_e2e.py
@@ -208,6 +208,33 @@ def test_data_on_changed():
         tester.run()
 
 
+def test_run_with_charmevents():
+    tester = _setup_with_test_file(
+        dedent(
+            """
+from scenario import State, Relation
+from scenario.context import CharmEvents
+
+from interface_tester.interface_test import Tester
+
+def test_data_on_changed():
+    relation = Relation(
+        endpoint='foobadooble',
+        interface='tracing',
+        remote_app_name='remote',
+        local_app_data={},
+    )
+    t = Tester(State(relations={relation}))
+    state_out = t.run(CharmEvents.relation_changed(relation))
+    t.assert_schema_valid()
+"""
+        )
+    )
+
+    with pytest.raises(NoSchemaError):
+        tester.run()
+
+
 def test_error_if_assert_schema_without_schema():
     tester = _setup_with_test_file(
         dedent(


### PR DESCRIPTION
If an `_Event` is passed to `_cast_event` then it doesn't need to be cast, but does need to be set to the `event` name.

Introduced in #21, sorry.