### PR TITLE
multiple endpoint support

### DIFF
--- a/interface_tester/interface_test.py
+++ b/interface_tester/interface_test.py
@@ -80,6 +80,9 @@ class _InterfaceTestContext:
     state_template: Optional[State]
     """Initial state that this test should be run with, according to the charm."""
 
+    endpoint: str = None
+    """Endpoint being tested. Only required if there's multiple endpoints with the same interface."""
+
     """The role (provider|requirer) that this test is about."""
     schema: Optional["DataBagSchema"] = None
     """Databag schema to validate the output relation with."""
@@ -481,7 +484,10 @@ class Tester:
         interface_name = self.ctx.interface_name
 
         # determine what charm endpoint we're testing.
-        endpoint = self._get_endpoint(supported_endpoints, role, interface_name=interface_name)
+
+        endpoint = self.ctx.endpoint or self._get_endpoint(
+            supported_endpoints, role, interface_name=interface_name
+        )
 
         for rel in state_template.relations:
             if rel.interface == interface_name:

--- a/interface_tester/interface_test.py
+++ b/interface_tester/interface_test.py
@@ -61,10 +61,11 @@ class _InterfaceTestContext:
 
     interface_name: str
     """The name of the interface that this test is about."""
+    endpoint: str
+    """Endpoint being tested."""
     version: int
     """The version of the interface that this test is about."""
     role: Role
-
     charm_type: CharmType
     """Charm class being tested"""
     supported_endpoints: dict
@@ -79,12 +80,6 @@ class _InterfaceTestContext:
     """Test function."""
     state_template: Optional[State]
     """Initial state that this test should be run with, according to the charm."""
-
-    endpoint: str = None
-    """
-    Endpoint being tested. 
-    Only required if there's multiple endpoints with the same interface.
-    """
 
     """The role (provider|requirer) that this test is about."""
     schema: Optional["DataBagSchema"] = None

--- a/interface_tester/interface_test.py
+++ b/interface_tester/interface_test.py
@@ -81,7 +81,10 @@ class _InterfaceTestContext:
     """Initial state that this test should be run with, according to the charm."""
 
     endpoint: str = None
-    """Endpoint being tested. Only required if there's multiple endpoints with the same interface."""
+    """
+    Endpoint being tested. 
+    Only required if there's multiple endpoints with the same interface.
+    """
 
     """The role (provider|requirer) that this test is about."""
     schema: Optional["DataBagSchema"] = None

--- a/interface_tester/plugin.py
+++ b/interface_tester/plugin.py
@@ -333,7 +333,7 @@ class InterfaceTester:
                 actions=self.actions,
                 supported_endpoints=self._gather_supported_endpoints(),
                 test_fn=test_fn,
-                juju_version=self._juju_version
+                juju_version=self._juju_version,
             )
             try:
                 with tester_context(ctx):

--- a/interface_tester/plugin.py
+++ b/interface_tester/plugin.py
@@ -63,6 +63,7 @@ class InterfaceTester:
         branch: Optional[str] = None,
         base_path: Optional[str] = None,
         interface_name: Optional[str] = None,
+        endpoint: Optional[str] = None,
         interface_version: Optional[int] = None,
         state_template: Optional[State] = None,
         juju_version: Optional[str] = None,
@@ -73,6 +74,7 @@ class InterfaceTester:
         """
 
         :arg interface_name: the interface to test.
+        :arg endpoint: the endpoint to test. If omitted, will test all endpoints with this interface.
         :param interface_version: what version of this interface we should be testing.
         :arg state_template: template state to use with the scenario test.
             The plugin will inject the relation spec under test, unless already defined.
@@ -96,6 +98,8 @@ class InterfaceTester:
             self._config = config
         if repo:
             self._repo = repo
+        if endpoint:
+            self._endpoint = endpoint
         if interface_name:
             self._interface_name = interface_name
         if interface_version is not None:
@@ -286,6 +290,9 @@ class InterfaceTester:
             schema = spec["schema"]
             for test in spec["tests"]:
                 for endpoint in endpoints:
+                    if self._endpoint and endpoint != self._endpoint:
+                        logger.debug(f"skipped compatible endpoint {endpoint}")
+                        continue
                     yield test, role, schema, endpoint
 
     def __repr__(self):
@@ -317,6 +324,7 @@ class InterfaceTester:
                 role=role,
                 schema=schema,
                 interface_name=self._interface_name,
+                endpoint=endpoint,
                 version=self._interface_version,
                 charm_type=self._charm_type,
                 state_template=self._state_template,
@@ -325,8 +333,7 @@ class InterfaceTester:
                 actions=self.actions,
                 supported_endpoints=self._gather_supported_endpoints(),
                 test_fn=test_fn,
-                juju_version=self._juju_version,
-                endpoint=endpoint,
+                juju_version=self._juju_version
             )
             try:
                 with tester_context(ctx):
@@ -354,6 +361,8 @@ class InterfaceTester:
             )
 
         if not ran_some:
-            msg = f"no tests gathered for {self._interface_name}/v{self._interface_version}"
+            msg = f"no tests gathered for {self._interface_name!r}/v{self._interface_version}"
+            if self._endpoint:
+                msg += f" and endpoint {self._endpoint!r}"
             logger.warning(msg)
             raise NoTestsRun(msg)

--- a/interface_tester/plugin.py
+++ b/interface_tester/plugin.py
@@ -74,7 +74,8 @@ class InterfaceTester:
         """
 
         :arg interface_name: the interface to test.
-        :arg endpoint: the endpoint to test. If omitted, will test all endpoints with this interface.
+        :arg endpoint: the endpoint to test.
+            If omitted, will test all endpoints with this interface.
         :param interface_version: what version of this interface we should be testing.
         :arg state_template: template state to use with the scenario test.
             The plugin will inject the relation spec under test, unless already defined.

--- a/interface_tester/plugin.py
+++ b/interface_tester/plugin.py
@@ -47,6 +47,7 @@ class InterfaceTester:
         self._meta = None
         self._actions = None
         self._config = None
+        self._endpoint = None
         self._interface_name = None
         self._interface_version = 0
         self._juju_version = None
@@ -68,6 +69,7 @@ class InterfaceTester:
         meta: Optional[Dict[str, Any]] = None,
         actions: Optional[Dict[str, Any]] = None,
         config: Optional[Dict[str, Any]] = None,
+        endpoint: Optional[str] = None,
     ):
         """
 
@@ -82,6 +84,8 @@ class InterfaceTester:
         :param meta: charm metadata.yaml contents.
         :param actions: charm actions.yaml contents.
         :param config: charm config.yaml contents.
+        :param endpoint: endpoint to test. In case there are multiple
+            endpoints with the same interface.
         :param juju_version: juju version that Scenario will simulate (also sets JUJU_VERSION
             envvar at charm runtime.)
         """
@@ -95,6 +99,8 @@ class InterfaceTester:
             self._config = config
         if repo:
             self._repo = repo
+        if endpoint:
+            self._endpoint = endpoint
         if interface_name:
             self._interface_name = interface_name
         if interface_version is not None:
@@ -295,6 +301,7 @@ class InterfaceTester:
         \tmeta={self._meta}
         \tactions={self._actions}
         \tconfig={self._config}
+        \tendpoint={self._endpoint}
         \tinterface_name={self._interface_name}
         \tinterface_version={self._interface_version}
         \tjuju_version={self._juju_version}
@@ -324,6 +331,7 @@ class InterfaceTester:
                 supported_endpoints=self._gather_supported_endpoints(),
                 test_fn=test_fn,
                 juju_version=self._juju_version,
+                endpoint=self._endpoint,
             )
             try:
                 with tester_context(ctx):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "3.2.1"
+version = "3.3.0"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "3.2.0"
+version = "3.2.1"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]

--- a/tests/resources/charm-like-path/tests/interface/conftest.py
+++ b/tests/resources/charm-like-path/tests/interface/conftest.py
@@ -33,7 +33,7 @@ def interface_tester(interface_tester: CRILikePathTester):
                 "tracing": {"interface": "tracing"},
                 "mysql-1": {"interface": "mysql"},
                 "mysql-2": {"interface": "mysql"},
-                         },
+            },
             "requires": {"tracing": {"interface": "tracing"}},
         },
         state_template=State(leader=True),

--- a/tests/resources/charm-like-path/tests/interface/conftest.py
+++ b/tests/resources/charm-like-path/tests/interface/conftest.py
@@ -29,7 +29,11 @@ def interface_tester(interface_tester: CRILikePathTester):
         charm_type=DummiCharm,
         meta={
             "name": "dummi",
-            "provides": {"tracing": {"interface": "tracing"}},
+            "provides": {
+                "tracing": {"interface": "tracing"},
+                "mysql-1": {"interface": "mysql"},
+                "mysql-2": {"interface": "mysql"},
+                         },
             "requires": {"tracing": {"interface": "tracing"}},
         },
         state_template=State(leader=True),

--- a/tests/unit/test_e2e.py
+++ b/tests/unit/test_e2e.py
@@ -529,9 +529,7 @@ def test_invalid_custom_schema():
         tester.run()
 
 
-@pytest.mark.parametrize(
-    "endpoint", ("mysql-1", "mysql-2")
-)
+@pytest.mark.parametrize("endpoint", ("mysql-1", "mysql-2"))
 @pytest.mark.parametrize("evt_type", ("changed", "created", "joined", "departed", "broken"))
 def test_multiple_endpoints(endpoint, evt_type):
     tester = _setup_with_test_file(

--- a/tests/unit/test_e2e.py
+++ b/tests/unit/test_e2e.py
@@ -61,7 +61,7 @@ def test_local_run(interface_tester):
     interface_tester.run()
 
 
-def _setup_with_test_file(test_file: str, schema_file: str = None):
+def _setup_with_test_file(test_file: str, schema_file: str = None, interface: str = "tracing"):
     td = tempfile.TemporaryDirectory()
     temppath = Path(td.name)
 
@@ -72,7 +72,7 @@ def _setup_with_test_file(test_file: str, schema_file: str = None):
             pth = temppath / "interfaces" / self._interface_name / f"v{self._interface_version}"
 
             test_dir = pth / "interface_tests"
-            test_dir.mkdir(parents=True)
+            test_dir.mkdir(parents=True, exist_ok=True)
             test_provider = test_dir / "test_provider.py"
             test_provider.write_text(test_file)
 
@@ -88,12 +88,16 @@ def _setup_with_test_file(test_file: str, schema_file: str = None):
 
     interface_tester = TempDirTester()
     interface_tester.configure(
-        interface_name="tracing",
+        interface_name=interface,
         charm_type=DummiCharm,
         meta={
             "name": "dummi",
             # interface tests should be agnostic to endpoint names
-            "provides": {"dead": {"interface": "tracing"}},
+            "provides": {
+                "dead": {"interface": "tracing"},
+                "mysql-1": {"interface": "mysql"},
+                "mysql-2": {"interface": "mysql"},
+            },
             "requires": {"beef-req": {"interface": "tracing"}},
         },
         state_template=State(leader=True),
@@ -543,8 +547,8 @@ def test_multiple_endpoints(endpoint, evt_type):
  def test_data_on_changed():
      t = Tester(State(
          relations={{Relation(
-             endpoint='{endpoint}',  # should not matter
-             interface='tracing',
+             endpoint='foobadoodle-doo',  # should not matter
+             interface='mysql',
              remote_app_name='remote',
              local_app_data={{}}
          )}}
@@ -552,7 +556,15 @@ def test_multiple_endpoints(endpoint, evt_type):
      state_out = t.run("{endpoint}-relation-{evt_type}")
      t.assert_schema_valid(schema=DataBagSchema())
  """
-        )
+        ),
+        interface="mysql",
     )
+
+    tests = tuple(tester._yield_tests())
+    # dummicharm is a provider of two mysql-interface endpoints called mysql-1 and mysql-2,
+    # so we have two tests
+    assert len(tests) == 2
+    assert set(t[1] for t in tests) == {"provider"}
+    assert [t[3] for t in tests] == ["mysql-1", "mysql-2"]
 
     tester.run()


### PR DESCRIPTION
Fixes #27 

Kinda hard to test, might want to create a better mock charm.

Manual testing strategy:
check out a charm that has multiple endpoints with the same interface on a single role, then pin this branch in your requirements.txt:

>    "pytest-interface-tester@git+http://github.com/canonical/pytest-interface-tester@multiple-endpoint-support",
