### PR TITLE
feat: additional customization options to support charmlibs monorepo

### DIFF
--- a/interface_tester/collector.py
+++ b/interface_tester/collector.py
@@ -28,6 +28,7 @@ from interface_tester.schema_base import DataBagSchema
 
 logger = logging.getLogger("interface_tests_checker")
 
+_DEFAULT_TESTS_DIR = "interface_tests"
 _NotFound = object()
 
 
@@ -224,10 +225,12 @@ def _scrape_module_for_tests(module: types.ModuleType) -> List[Callable[[None], 
     return tests
 
 
-def _gather_test_cases_for_version(version_dir: Path, interface_name: str, version: int):
+def _gather_test_cases_for_version(
+    version_dir: Path, interface_name: str, version: int, *, tests_dir: str = _DEFAULT_TESTS_DIR
+):
     """Collect interface test cases from a directory containing an interface version spec."""
 
-    interface_tests_dir = version_dir / "interface_tests"
+    interface_tests_dir = version_dir / tests_dir
 
     provider_test_cases = []
     requirer_test_cases = []
@@ -261,7 +264,7 @@ def _gather_test_cases_for_version(version_dir: Path, interface_name: str, versi
 
 
 def gather_test_spec_for_version(
-    version_dir: Path, interface_name: str, version: int
+    version_dir: Path, interface_name: str, version: int, *, tests_dir: str = _DEFAULT_TESTS_DIR
 ) -> InterfaceTestSpec:
     """Collect interface tests from an interface/version subdirectory.
 
@@ -270,7 +273,7 @@ def gather_test_spec_for_version(
     """
 
     provider_test_cases, requirer_test_cases = _gather_test_cases_for_version(
-        version_dir, interface_name, version
+        version_dir, interface_name, version, tests_dir=tests_dir
     )
     schemas = get_schemas(version_dir / "schema.py")
     charms = _gather_charms_for_version(version_dir)
@@ -291,7 +294,7 @@ def gather_test_spec_for_version(
 
 
 def _gather_tests_for_interface(
-    interface_dir: Path, interface_name: str
+    interface_dir: Path, interface_name: str, *, tests_dir: str = _DEFAULT_TESTS_DIR
 ) -> Dict[str, InterfaceTestSpec]:
     """Collect interface tests from an interface subdirectory.
 
@@ -308,12 +311,14 @@ def _gather_tests_for_interface(
             )
             continue
         tests[version_dir.name] = gather_test_spec_for_version(
-            version_dir, interface_name, version_n
+            version_dir, interface_name, version_n, tests_dir=tests_dir
         )
     return tests
 
 
-def collect_tests(path: Path, include: str = "*") -> Dict[str, Dict[str, InterfaceTestSpec]]:
+def collect_tests(
+    path: Path, include: str = "*", *, tests_dir: str = _DEFAULT_TESTS_DIR
+) -> Dict[str, Dict[str, InterfaceTestSpec]]:
     """Gather the test cases collected from this path.
 
     Returns a dict structured as follows:
@@ -335,6 +340,8 @@ def collect_tests(path: Path, include: str = "*") -> Dict[str, Dict[str, Interfa
             continue  # skip
         logger.info("collecting tests for interface %s" % interface_dir_name)
         interface_name = interface_dir_name.replace("-", "_")
-        tests[interface_name] = _gather_tests_for_interface(interface_dir, interface_name)
+        tests[interface_name] = _gather_tests_for_interface(
+            interface_dir, interface_name, tests_dir=tests_dir
+        )
 
     return tests

--- a/interface_tester/plugin.py
+++ b/interface_tester/plugin.py
@@ -93,10 +93,10 @@ class InterfaceTester:
         :param config: charm config.yaml contents.
         :param juju_version: juju version that Scenario will simulate (also sets JUJU_VERSION
             envvar at charm runtime.)
-        :param interface_subdir: Subdirectory to look for versioned interface direstories in
+        :param interface_subdir: Subdirectory to look for versioned interface directories in
             under interfaces/interface_name.
         :param tests_dir: Name of tests directory under
-            interfaces/interface_name/interface_subdir/vN.
+            interfaces/<interface_name>/<interface_subdir>/v<N>.
         """
         if charm_type:
             self._charm_type = charm_type

--- a/interface_tester/plugin.py
+++ b/interface_tester/plugin.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 import logging
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from subprocess import PIPE, Popen
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type
@@ -324,6 +325,28 @@ class InterfaceTester:
         \tjuju_version={self._juju_version}
         \tstate_template={self._state_template}>"""
 
+    @contextmanager
+    def context(self, test_fn: Callable, role: RoleLiteral, schema: DataBagSchema, endpoint: str):
+        logger.debug(f"Entering context {self!r}, {role=!r} {endpoint=!r} {schema=}.")
+        self._validate_config()  # will raise if misconfigured
+        ctx = _InterfaceTestContext(
+            role=role,
+            schema=schema,
+            interface_name=self._interface_name,
+            endpoint=endpoint,
+            version=self._interface_version,
+            charm_type=self._charm_type,
+            state_template=self._state_template,
+            meta=self.meta,
+            config=self.config,
+            actions=self.actions,
+            supported_endpoints=self._gather_supported_endpoints(),
+            test_fn=test_fn,
+            juju_version=self._juju_version,
+        )
+        with tester_context(ctx):
+            yield ctx
+
     def run(self) -> bool:
         """Run interface tests.
 
@@ -335,23 +358,8 @@ class InterfaceTester:
         ran_some = False
 
         for test_fn, role, schema, endpoint in self._yield_tests():
-            ctx = _InterfaceTestContext(
-                role=role,
-                schema=schema,
-                interface_name=self._interface_name,
-                endpoint=endpoint,
-                version=self._interface_version,
-                charm_type=self._charm_type,
-                state_template=self._state_template,
-                meta=self.meta,
-                config=self.config,
-                actions=self.actions,
-                supported_endpoints=self._gather_supported_endpoints(),
-                test_fn=test_fn,
-                juju_version=self._juju_version,
-            )
             try:
-                with tester_context(ctx):
+                with self.context(test_fn, role, schema, endpoint) as ctx:
                     test_fn()
             except Exception as e:
                 logger.exception(f"Interface tester plugin failed with {e}")

--- a/interface_tester/plugin.py
+++ b/interface_tester/plugin.py
@@ -52,6 +52,8 @@ class InterfaceTester:
         self._interface_version = 0
         self._juju_version = None
         self._state_template = None
+        self._interface_subdir = ""
+        self._tests_dir = "interface_tests"
 
         self._charm_spec_cache = None
 
@@ -70,6 +72,8 @@ class InterfaceTester:
         meta: Optional[Dict[str, Any]] = None,
         actions: Optional[Dict[str, Any]] = None,
         config: Optional[Dict[str, Any]] = None,
+        interface_subdir: Optional[str] = None,
+        tests_dir: Optional[str] = None,
     ):
         """
 
@@ -88,6 +92,10 @@ class InterfaceTester:
         :param config: charm config.yaml contents.
         :param juju_version: juju version that Scenario will simulate (also sets JUJU_VERSION
             envvar at charm runtime.)
+        :param interface_subdir: Subdirectory to look for versioned interface direstories in
+            under interfaces/interface_name.
+        :param tests_dir: Name of tests directory under
+            interfaces/interface_name/interface_subdir/vN.
         """
         if charm_type:
             self._charm_type = charm_type
@@ -113,6 +121,10 @@ class InterfaceTester:
             self._base_path = base_path
         if juju_version:
             self._juju_version = juju_version
+        if interface_subdir is not None:
+            self._interface_subdir = interface_subdir
+        if tests_dir is not None:
+            self._tests_dir = tests_dir
 
     def _validate_config(self):
         """Validate the configuration of the tester.
@@ -209,6 +221,7 @@ class InterfaceTester:
                 / repo_name
                 / self._base_path
                 / self._interface_name.replace("-", "_")
+                / self._interface_subdir
                 / f"v{self._interface_version}"
             )
             if not intf_spec_path.exists():
@@ -222,6 +235,7 @@ class InterfaceTester:
                 intf_spec_path,
                 interface_name=self._interface_name,
                 version=self._interface_version,
+                tests_dir=self._tests_dir,
             )
 
         return tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-interface-tester"
 
-version = "3.3.1"
+version = "3.4.0"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" },
 ]


### PR DESCRIPTION
With https://github.com/canonical/charmlibs/pull/195 merged, the `charmlibs` monorepo now collects and runs interface tests in CI. This PR adds some additional flexibility to the interface tester API to support the charmlibs layout and let us handle test collection and execution separately (with `pytest`) with the `context` entrypoint (an alternative to `run`). `charmlibs@main` currently uses the code from this branch, though it only makes use of the `context` entrypoint -- not the configurable test locations, since it takes care of test discovery separately.